### PR TITLE
update .modisHTTP to version 6

### DIFF
--- a/R/ModisDownload.R
+++ b/R/ModisDownload.R
@@ -110,7 +110,7 @@ getNativeTemporalResolution <- function(product) {
 }
 #-----------------------
 
-.modisHTTP <- function(x,v='005',opt) {
+.modisHTTP <- function(x,v='006',opt) {
   if (!requireNamespace("RCurl",quietly = TRUE)) stop("Package RCurl is not installed")
   mp <- modisProducts(version=v)
   if (is.numeric(x)) {


### PR DESCRIPTION
HTTP address only supports version 6
ModisDownload() is throwing an error of 'Error in .modisHTTP(x, v = version, opt = opt) : 
  the http address does not exist OR Server is down!' due to the HTTP address being unable to find the specified default version='005'